### PR TITLE
Rename match

### DIFF
--- a/Civi/Osdi/ActionNetwork/Matcher/Tag/Basic.php
+++ b/Civi/Osdi/ActionNetwork/Matcher/Tag/Basic.php
@@ -5,7 +5,7 @@ namespace Civi\Osdi\ActionNetwork\Matcher\Tag;
 use Civi\Osdi\ActionNetwork\RemoteSystem;
 use Civi\Osdi\LocalRemotePair;
 use Civi\Osdi\RemoteSystemInterface;
-use Civi\Osdi\Result\Match as MatchResult;
+use Civi\Osdi\Result\Matched as MatchResult;
 
 class Basic implements \Civi\Osdi\MatcherInterface {
 

--- a/Civi/Osdi/ActionNetwork/SingleSyncer/Person/Person.php
+++ b/Civi/Osdi/ActionNetwork/SingleSyncer/Person/Person.php
@@ -11,7 +11,7 @@ use Civi\Osdi\PersonSyncState;
 use Civi\Osdi\RemoteObjectInterface;
 use Civi\Osdi\RemoteSystemInterface;
 use Civi\Osdi\Result\MapAndWrite as MapAndWriteResult;
-use Civi\Osdi\Result\Match;
+use Civi\Osdi\Result\Matched;
 use Civi\Osdi\Result\Sync;
 use Civi\Osdi\SingleSyncerInterface;
 use Civi\Osdi\Util;
@@ -294,7 +294,7 @@ class Person implements SingleSyncerInterface {
       return $pair->setIsError(TRUE)->setMessage('error finding match');
     }
 
-    elseif (Match::NO_MATCH == $matchResult->getStatusCode()) {
+    elseif (Matched::NO_MATCH == $matchResult->getStatusCode()) {
       if (!$this->newRemoteShouldBeCreatedForLocal($pair)) {
         return $pair;
       }
@@ -325,7 +325,7 @@ class Person implements SingleSyncerInterface {
       return $pair->setIsError(TRUE)->setMessage('error finding match');
     }
 
-    elseif (Match::NO_MATCH == $matchResult->getStatusCode()) {
+    elseif (Matched::NO_MATCH == $matchResult->getStatusCode()) {
       $syncResult = $this->oneWayWriteFromRemote($pair);
       return $this->fillLocalRemotePairFromSyncResult($syncResult, $pair);
     }

--- a/Civi/Osdi/ActionNetwork/SingleSyncer/Person/PersonLocalRemotePairTrait.php
+++ b/Civi/Osdi/ActionNetwork/SingleSyncer/Person/PersonLocalRemotePairTrait.php
@@ -6,7 +6,7 @@ use Civi\Osdi\Exception\EmptyResultException;
 use Civi\Osdi\Exception\InvalidArgumentException;
 use Civi\Osdi\LocalRemotePair;
 use Civi\Osdi\PersonSyncState;
-use Civi\Osdi\Result\Match;
+use Civi\Osdi\Result\Matched;
 use Civi\Osdi\Result\Sync;
 use Civi\Osdi\Util;
 
@@ -58,10 +58,10 @@ trait PersonLocalRemotePairTrait {
   }
 
   protected function fillLocalRemotePairFromNewfoundMatch(
-    Match $matchResult,
+    Matched $matchResult,
     LocalRemotePair $pair
   ): LocalRemotePair {
-    if (Match::ORIGIN_LOCAL === $matchResult->getOrigin()) {
+    if (Matched::ORIGIN_LOCAL === $matchResult->getOrigin()) {
       $localObject = $matchResult->getOriginObject();
       $remoteObject = $matchResult->getMatch();
     }

--- a/Civi/Osdi/LocalRemotePair.php
+++ b/Civi/Osdi/LocalRemotePair.php
@@ -5,7 +5,7 @@ namespace Civi\Osdi;
 use Civi\Osdi\Exception\InvalidArgumentException;
 use Civi\Osdi\Exception\InvalidOperationException;
 use Civi\Osdi\LocalObject\LocalObjectInterface;
-use Civi\Osdi\Result\Match;
+use Civi\Osdi\Result\Matched;
 use Civi\Osdi\Result\ResultStack;
 use Civi\Osdi\Result\Sync;
 
@@ -24,7 +24,7 @@ class LocalRemotePair {
 
   private ?string $message;
   private ?PersonSyncState $personSyncState;
-  private ?Match $matchResult;
+  private ?Matched $matchResult;
   private ?Sync $syncResult;
 
   private $origin;
@@ -35,7 +35,7 @@ class LocalRemotePair {
       bool $isError = FALSE,
       string $message = NULL,
       $personSyncState = NULL,
-      Match $matchResult = NULL,
+      Matched $matchResult = NULL,
       Sync $syncResult = NULL) {
     $this->localObject = $localObject;
     $this->remoteObject = $remoteObject;
@@ -151,11 +151,11 @@ class LocalRemotePair {
     return $this;
   }
 
-  public function getMatchResult(): ?Match {
+  public function getMatchResult(): ?Matched {
     return $this->matchResult;
   }
 
-  public function setMatchResult(?Match $matchResult): self {
+  public function setMatchResult(?Matched $matchResult): self {
     $this->matchResult = $matchResult;
     return $this;
   }

--- a/Civi/Osdi/MatcherInterface.php
+++ b/Civi/Osdi/MatcherInterface.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Osdi;
 
-use Civi\Osdi\Result\Match as MatchResult;
+use Civi\Osdi\Result\Matched as MatchResult;
 
 interface MatcherInterface {
 

--- a/Civi/Osdi/Result/Matched.php
+++ b/Civi/Osdi/Result/Matched.php
@@ -7,7 +7,7 @@ use Civi\Osdi\LocalObject\LocalObjectInterface;
 use Civi\Osdi\LocalRemotePair;
 use Civi\Osdi\RemoteObjectInterface;
 
-class Match extends AbstractResult implements \Civi\Osdi\ResultInterface {
+class Matched extends AbstractResult implements \Civi\Osdi\ResultInterface {
 
   const ERROR_INDETERMINATE = 'provided criteria do not uniquely identify a record';
 
@@ -127,7 +127,7 @@ class Match extends AbstractResult implements \Civi\Osdi\ResultInterface {
     return $this->localObject;
   }
 
-  public function setLocalObject(?LocalObjectInterface $localObject): Match {
+  public function setLocalObject(?LocalObjectInterface $localObject): Matched {
     $this->localObject = $localObject;
     return $this;
   }
@@ -136,7 +136,7 @@ class Match extends AbstractResult implements \Civi\Osdi\ResultInterface {
     return $this->remoteObject;
   }
 
-  public function setRemoteObject(?RemoteObjectInterface $remoteObject): Match {
+  public function setRemoteObject(?RemoteObjectInterface $remoteObject): Matched {
     $this->remoteObject = $remoteObject;
     return $this;
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ install it with the command-line tool [cv](https://github.com/civicrm/cv). Depen
 ```bash
 cd <extension-dir>
 cv dl osdi-client@https://github.com/lemniscus/osdi-client/archive/master.zip
-cd osdi-client/hal-client
+cd osdi-client/vendor/hal-client
 composer update
 cv en osdi-client
 ```

--- a/tests/phpunit/CRM/OSDI/ActionNetwork/Matcher/PersonTest.php
+++ b/tests/phpunit/CRM/OSDI/ActionNetwork/Matcher/PersonTest.php
@@ -62,10 +62,10 @@ class CRM_OSDI_ActionNetwork_Matcher_PersonTest extends \PHPUnit\Framework\TestC
     return $pair;
   }
 
-  private function assertMatchResultIsNotError_NoMatch_ZeroCount(\Civi\Osdi\Result\Match $matchResult): void {
+  private function assertMatchResultIsNotError_NoMatch_ZeroCount(\Civi\Osdi\Result\Matched $matchResult): void {
     $this->assertNull($matchResult->getMatch());
     $this->assertFalse($matchResult->isError());
-    $this->assertEquals(\Civi\Osdi\Result\Match::NO_MATCH, $matchResult->getStatusCode());
+    $this->assertEquals(\Civi\Osdi\Result\Matched::NO_MATCH, $matchResult->getStatusCode());
   }
 
   public function testRemoteMatch_OneToOneEmailSuccess() {
@@ -99,7 +99,7 @@ class CRM_OSDI_ActionNetwork_Matcher_PersonTest extends \PHPUnit\Framework\TestC
     $matchResult = $this->matcher->tryToFindMatchForLocalObject(self::makePair($contactId));
     $this->assertNull($matchResult->getMatch());
     $this->assertTrue($matchResult->isError());
-    $this->assertEquals(\Civi\Osdi\Result\Match::ERROR_INVALID_ID, $matchResult->getStatusCode());
+    $this->assertEquals(\Civi\Osdi\Result\Matched::ERROR_INVALID_ID, $matchResult->getStatusCode());
   }*/
 
   public function testRemoteMatch_NoEmail() {

--- a/tests/phpunit/CRM/OSDI/ActionNetwork/SingleSyncer/TagBasicTest.php
+++ b/tests/phpunit/CRM/OSDI/ActionNetwork/SingleSyncer/TagBasicTest.php
@@ -174,7 +174,7 @@ class CRM_OSDI_ActionNetwork_SingleSyncer_Tag_BasicTest extends PHPUnit\Framewor
     $pair = $syncer->matchAndSyncIfEligible($localTag);
     $resultStack = $pair->getResultStack();
     $fetchFindMatchResult = $resultStack->getLastOfType(FetchOldOrFindNewMatch::class);
-    $matchResult = $resultStack->getLastOfType(\Civi\Osdi\Result\Match::class);
+    $matchResult = $resultStack->getLastOfType(\Civi\Osdi\Result\Matched::class);
     $mapAndWriteResult = $resultStack->getLastOfType(MapAndWrite::class);
     $syncEligibleResult = $resultStack->getLastOfType(SyncEligibility::class);
     $syncResult = $resultStack->getLastOfType(Sync::class);
@@ -244,7 +244,7 @@ class CRM_OSDI_ActionNetwork_SingleSyncer_Tag_BasicTest extends PHPUnit\Framewor
     $pair = $syncer->matchAndSyncIfEligible($remoteTag);
     $resultStack = $pair->getResultStack();
     $fetchFindMatchResult = $resultStack->getLastOfType(FetchOldOrFindNewMatch::class);
-    $matchResult = $resultStack->getLastOfType(\Civi\Osdi\Result\Match::class);
+    $matchResult = $resultStack->getLastOfType(\Civi\Osdi\Result\Matched::class);
     $mapAndWriteResult = $resultStack->getLastOfType(MapAndWrite::class);
     $syncEligibleResult = $resultStack->getLastOfType(SyncEligibility::class);
     $syncResult = $resultStack->getLastOfType(Sync::class);
@@ -323,14 +323,14 @@ class CRM_OSDI_ActionNetwork_SingleSyncer_Tag_BasicTest extends PHPUnit\Framewor
     $pair = $syncer->matchAndSyncIfEligible($remoteTag);
     $resultStack = $pair->getResultStack();
     $fetchFindMatchResult = $resultStack->getLastOfType(FetchOldOrFindNewMatch::class);
-    $matchResult = $resultStack->getLastOfType(\Civi\Osdi\Result\Match::class);
+    $matchResult = $resultStack->getLastOfType(\Civi\Osdi\Result\Matched::class);
     $mapAndWriteResult = $resultStack->getLastOfType(MapAndWrite::class);
     $syncEligibleResult = $resultStack->getLastOfType(SyncEligibility::class);
     $syncResult = $resultStack->getLastOfType(Sync::class);
     $savedMatch = $syncResult->getState();
 
     self::assertEquals(FetchOldOrFindNewMatch::FOUND_NEW_MATCH, $fetchFindMatchResult->getStatusCode());
-    self::assertEquals(\Civi\Osdi\Result\Match::FOUND_MATCH, $matchResult->getStatusCode());
+    self::assertEquals(\Civi\Osdi\Result\Matched::FOUND_MATCH, $matchResult->getStatusCode());
     self::assertEquals(MapAndWrite::NO_CHANGES_TO_WRITE, $mapAndWriteResult->getStatusCode());
     self::assertEquals(SyncEligibility::ELIGIBLE, $syncEligibleResult->getStatusCode());
     self::assertEquals(Sync::SUCCESS, $syncResult->getStatusCode());

--- a/tests/phpunit/CRM/OSDI/Result/ResultStackTest.php
+++ b/tests/phpunit/CRM/OSDI/Result/ResultStackTest.php
@@ -42,7 +42,7 @@ class CRM_OSDI_Result_ResultStackTest extends PHPUnit\Framework\TestCase impleme
   public function testForeach() {
     $testData = [
       0 => new \Civi\Osdi\Result\Sync(),
-      1 => new \Civi\Osdi\Result\Match(\Civi\Osdi\Result\Match::ORIGIN_LOCAL)
+      1 => new \Civi\Osdi\Result\Matched(\Civi\Osdi\Result\Matched::ORIGIN_LOCAL)
     ];
 
     $stack = new Civi\Osdi\Result\ResultStack;


### PR DESCRIPTION
See #1 

'Matched' seemed close enough fit with language, but I'm really just getting to know the code a bit so feel free to ignore and rename it yourself!