### PR TITLE
Fix loadById issue

### DIFF
--- a/Civi/Osdi/ActionNetwork/Object/AbstractRemoteObject.php
+++ b/Civi/Osdi/ActionNetwork/Object/AbstractRemoteObject.php
@@ -226,22 +226,25 @@ abstract class AbstractRemoteObject implements RemoteObjectInterface {
   }
 
   public function getUrlForRead(): ?string {
-    try {
-      if ($selfLink = $this->_resource->getFirstLink('self')) {
-        return $selfLink->getHref();
+
+    if ($this->_resource) {
+      try {
+        $selfLink = $this->_resource->getFirstLink('self');
+        if ($selfLink) {
+          return $selfLink->getHref();
+        }
       }
+      catch (\Throwable $e) {}
+    }
+
+    try {
+      return $this->constructOwnUrl();
     }
     catch (\Throwable $e) {
-      try {
-        return $this->constructOwnUrl();
-      }
-      catch (\Throwable $e) {
-        throw new EmptyResultException(
-          'Could not find or create url for "%s" with type "%s" and id "%s"',
-          get_called_class(), $this->getType(), $this->getId());
-      }
+      throw new EmptyResultException(
+        'Could not find or create url for "%s" with type "%s" and id "%s"',
+        get_called_class(), $this->getType(), $this->getId());
     }
-    return NULL;
   }
 
   public function getUrlForUpdate(): string {


### PR DESCRIPTION
I came across this in a DonationTest test that was throwing an error while using loadById(). The problem is at https://github.com/lemniscus/osdi-client/commit/8ae5aaf091c6f1cf076ee357fb76619352abdc7f#diff-69df3ba956b6029fe4a3798babfd1958f023d8ce423b95a9f609074f23acd0a9L230
where we assume that `$this->_resource` exists, which it won't in the context of `loadById()`.

I believe this PR is a fix, but the logic was not entirely clear, so apols if I've missed a nuance.

The new code does this:

1. *if* we have a resource, first try to access the self link, falling back to...
2. try constructOwnUrl()

The signature gives a return type of string|null. It will return null only if either of the methods returns null, yet it seems more likely from the implementing code that the methods *throw* in which case we throw too. So it might be good to clarify when null is going to be a possibility; at the minute callers of this have to handle both exceptions and nulls, which is an overhead that might be avoidable if there's not an important distinction.
