### PR TITLE
avoid undefined variable error when getSingleSyncer fails and $pair is undefined.

### DIFF
--- a/Civi/Osdi/ActionNetwork/BatchSyncer/PersonBasic.php
+++ b/Civi/Osdi/ActionNetwork/BatchSyncer/PersonBasic.php
@@ -119,6 +119,7 @@ class PersonBasic implements BatchSyncerInterface {
         continue;
       }
 
+      $pair = NULL;
       try {
         $pair = $this->getSingleSyncer()->matchAndSyncIfEligible($remotePerson);
         $syncResult = $pair->getResultStack()->getLastOfType(Sync::class);


### PR DESCRIPTION
Very minor contribution : ) - but nice to avoid getting noise via cron job emails.