### PR TITLE
avoid Symfony listener error

### DIFF
--- a/osdi_client.php
+++ b/osdi_client.php
@@ -62,7 +62,7 @@ function osdi_client_add_syncprofile_dependent_listeners(): void {
   }
 
   // the dummy listener helps us only add the other listeners once
-  Civi::dispatcher()->addListener(__FUNCTION__, 'dummy');
+  Civi::dispatcher()->addListener(__FUNCTION__, ['dummy']);
   Civi::dispatcher()->addListener('civi.dao.preDelete', ['\Civi\Osdi\CrmEventDispatch', 'daoPreDelete']);
   Civi::dispatcher()->addListener('civi.dao.preUpdate', ['\Civi\Osdi\CrmEventDispatch', 'daoPreUpdate']);
   Civi::dispatcher()->addListener('&hook_civicrm_alterLocationMergeData', ['\Civi\Osdi\CrmEventDispatch', 'alterLocationMergeData']);


### PR DESCRIPTION
> Symfony\Component\EventDispatcher\EventDispatcher::addListener(): Argument #2 () must be of type callable|array, string given

I think this argument should be an array - this is the one that has been causing us problems for a while.